### PR TITLE
BREAKING CHANGE: Added AdditionalData to Flags

### DIFF
--- a/src/Models/Flags.cs
+++ b/src/Models/Flags.cs
@@ -2,6 +2,7 @@
 {
 	using System.Collections.Generic;
 	using Newtonsoft.Json;
+	using Newtonsoft.Json.Linq;
 
 	/// <summary>
 	/// The flags object contains various metadata information related to the request.
@@ -9,10 +10,11 @@
 	public class Flags
 	{
 		/// <summary>
-		/// Undocumented, presumably a list of stations.
+		/// Additional unmapped flags end up here.
 		/// </summary>
-		[JsonProperty(PropertyName = "darksky-stations")]
-		public List<string> DarkskyStations { get; set; }
+		/// <remarks>optional.</remarks>
+		[JsonExtensionData]
+		public IDictionary<string, JToken> AdditionalData { get; set; }
 
 		/// <summary>
 		/// The presence of this property indicates that the Dark Sky data source supports the given
@@ -22,30 +24,6 @@
 		/// <remarks>optional.</remarks>
 		[JsonProperty(PropertyName = "darksky-unavailable")]
 		public string DarkskyUnavailable { get; set; }
-
-		/// <summary>
-		/// Undocumented.
-		/// </summary>
-		[JsonProperty(PropertyName = "isd-stations")]
-		public List<string> IsdStations { get; set; }
-
-		/// <summary>
-		/// Undocumented.
-		/// </summary>
-		[JsonProperty(PropertyName = "lamp-stations")]
-		public List<string> LampStations { get; set; }
-
-		/// <summary>
-		/// Undocumented.
-		/// </summary>
-		[JsonProperty(PropertyName = "madis-stations")]
-		public List<string> MadisStations { get; set; }
-
-		/// <summary>
-		/// Undocumented.
-		/// </summary>
-		[JsonProperty(PropertyName = "metno-license")]
-		public string MetnoLicense { get; set; }
 
 		/// <summary>
 		/// Undocumented.

--- a/test/UnitTests/FlagsUnitTests.cs
+++ b/test/UnitTests/FlagsUnitTests.cs
@@ -1,0 +1,23 @@
+namespace DarkSky.UnitTests.Models
+{
+	using System;
+	using DarkSky.UnitTests.Fixtures;
+	using Xunit;
+
+	public class FlagsUnitTests : IClassFixture<ResponseFixture>
+	{
+		ResponseFixture _fixture;
+
+		public FlagsUnitTests(ResponseFixture fixture)
+		{
+			_fixture = fixture;
+		}
+
+		[Fact]
+		public void FlagsAdditionalDataExistsTest()
+		{
+			var forecast = _fixture.MissingDataResponse;
+			Assert.NotEmpty(forecast.Response.Flags.AdditionalData);
+		}
+	}
+}


### PR DESCRIPTION
This will catch all the undocumented fields that may exist.

Json.NET will still throw an error if MissingMemberHandling.Error used.