### PR TITLE
Non breaking: Separate the GetForecast call to two functions

### DIFF
--- a/src/Models/DarkSkyResponse.cs
+++ b/src/Models/DarkSkyResponse.cs
@@ -36,6 +36,11 @@
 		public ResponseHeaders Headers { get; set; }
 
 		/// <summary>
+		/// Holds the raw (hopefully json) response from the body of the http request.
+		/// </summary>
+		public string RawResponse { get; set; }
+
+		/// <summary>
 		/// The response from the Dark Sky API is a success status.
 		/// </summary>
 		public bool IsSuccessStatus { get; set; }

--- a/tests/IntegrationTests/DarkSkyServiceIntegrationTests.cs
+++ b/tests/IntegrationTests/DarkSkyServiceIntegrationTests.cs
@@ -4,6 +4,7 @@ namespace DarkSky.Tests.IntegrationTests.Services
 	using System.Collections.Generic;
 	using System.Globalization;
 	using System.Threading.Tasks;
+	using DarkSky.Models;
 	using DarkSky.Services;
 	using Microsoft.Extensions.Configuration;
 	using Newtonsoft.Json;
@@ -23,6 +24,23 @@ namespace DarkSky.Tests.IntegrationTests.Services
 			var apiKey = config.GetValue<string>(_apiEnvVar);
 			Assert.False(string.IsNullOrWhiteSpace(apiKey), $"You must set the environment variable {_apiEnvVar}");
 			_darkSky = new DarkSkyService(apiKey);
+		}
+
+		[Fact]
+		public async Task RawResponseIsExpectedJson()
+		{
+			var forecast = await _darkSky.GetDarkSkyResponse(_latitude, _longitude, new DarkSkyService.OptionalParameters
+			{
+				ExtendHourly = true,
+				DataBlocksToExclude = new List<ExclusionBlock> { ExclusionBlock.Flags },
+				LanguageCode = "x-pig-latin",
+				MeasurementUnits = "si",
+			});
+			var model = JsonConvert.DeserializeObject<Forecast>(forecast.RawResponse);
+
+			Assert.NotNull(forecast);
+			Assert.NotNull(forecast.Headers);
+			Assert.IsType<Forecast>(model);
 		}
 
 		[Fact]


### PR DESCRIPTION
Non breaking: Separate the GetForecast call to two functions - get response with model as json and deserialize json into model.

@amweiss - this change was led because I wanted to access the raw json returned rather than object model (I'm going to parse the json via jsonpath to build out some simple key-value-pairs ready for UI use, but in an extensible way). No stress if you don't like this!

Many thanks for the work done to create the library.